### PR TITLE
rbac user cluster roles DK-1854

### DIFF
--- a/chart/k8skafka-controller/templates/clusterrole-edit.yaml
+++ b/chart/k8skafka-controller/templates/clusterrole-edit.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.clusterRBAC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8skafka-controller.fullname" . }}-edit
+  labels:
+    app.kubernetes.io/name: {{ include "k8skafka-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8skafka-controller.chart" . }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+rules:
+- apiGroups:
+  - "kafka.infra.doodle.com"
+  resources:
+  - kafkatopics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "kafka.infra.doodle.com"
+  resources:
+  - kafkatopics/status
+  verbs:
+  - get
+{{- end }}

--- a/chart/k8skafka-controller/templates/clusterrole-view.yaml
+++ b/chart/k8skafka-controller/templates/clusterrole-view.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.clusterRBAC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8skafka-controller.fullname" . }}-view
+  labels:
+    app.kubernetes.io/name: {{ include "k8skafka-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8skafka-controller.chart" . }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+rules:
+- apiGroups:
+  - "kafka.infra.doodle.com"
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "kafka.infra.doodle.com"
+  resources:
+  - kafkatopics/status
+  verbs:
+  - get
+{{- end }}


### PR DESCRIPTION
Adds two cluster roles, one for read and one for edit/admin access.
Both come with the default aggregate labels to include them in the according roles.