### PR TITLE
Use kaniko instead dind DK-1985

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ podTemplate(label: 'k8skafka-controller',
             bumpImageVersion(env.TAG_NAME)
 
             tgz="k8skafka-controller-${version}.tgz"
+            sh "mkdir chart/k8skafka-controller/crds"
             sh "cp config/crd/bases/* chart/k8skafka-controller/crds"
             sh "helm package chart/k8skafka-controller"
           }


### PR DESCRIPTION
## Current situation
Our controller builds fail because of network problems with dind. Network connections can't be setup within the docker build.
This is most likely related to the recent k8s 1.18 upgrade.

## Proposal
A better long term solution is to migrate to kaniko instead using the docker daemon which will be deprecated in k8s soon.
You can see a build with kaniko here: https://builder.internal.doodle-test.com/job/k8sdb-controller/view/tags/job/v0.0.6-pre/19/console

Note: The debug build is required to include a busybox to prestart the container but only trigger a build in a later stage.
