### PR TITLE
use error instead panic DK-2668

### DIFF
--- a/kafka/connection.go
+++ b/kafka/connection.go
@@ -3,12 +3,13 @@ package kafka
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	k "github.com/segmentio/kafka-go"
 	"math"
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
+	k "github.com/segmentio/kafka-go"
 )
 
 const (
@@ -192,7 +193,7 @@ func (c *Connection) GetTopic(name string) (*Topic, error) {
 
 	partitions, err := conn.ReadPartitions()
 	if err != nil {
-		panic(err.Error())
+		return nil, err
 	}
 
 	var numberOfPartitions int64 = 0


### PR DESCRIPTION
## Current situation 
The kafka controller is currently crash looping in staging.

## Proposal
Not sure for what reason panic was chosen here but it should be fine to just return the error and let the reconciliation update the status condition to failed.