### PR TITLE
fix pod monitor

### DIFF
--- a/chart/k8skafka-controller/Chart.yaml
+++ b/chart/k8skafka-controller/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 name: k8skafka-controller
 sources:
 - https://github.com/DoodleScheduling/k8skafka-controller
-version: 0.2.0
+version: 0.2.1

--- a/chart/k8skafka-controller/templates/podmonitor.yaml
+++ b/chart/k8skafka-controller/templates/podmonitor.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: {{ .Values.metricsPath }}
     interval: {{ .Values.podMonitor.interval }}


### PR DESCRIPTION
## Current situation
`endpoints` is not a valid setting for PodMonitor

## Proposal
Use podMetricsEndpoints instead
