### PR TITLE
fix(chart): securityContext and rbac for metrics proxy

### DIFF
--- a/chart/k8skafka-controller/Chart.yaml
+++ b/chart/k8skafka-controller/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 name: k8skafka-controller
 sources:
 - https://github.com/DoodleScheduling/k8skafka-controller
-version: 0.3.3
+version: 0.4.0

--- a/chart/k8skafka-controller/templates/deployment.yaml
+++ b/chart/k8skafka-controller/templates/deployment.yaml
@@ -81,17 +81,17 @@ spec:
         {{- end }}
       {{- if .Values.kubeRBACProxy.enabled }}
       - args:
-          - --secure-listen-address=0.0.0.0:8443
-          - --upstream=http://127.0.0.1:{{ .Values.metricsPort }}
-          - --logtostderr=true
-          - --v=0
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:{{ .Values.metricsPort }}
+        - --logtostderr=true
+        - --v=0
+        image: {{ .Values.kubeRBACProxy.image }}
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:
-          - containerPort: 8443
-            name: https
-            protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
         resources:
           {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
         securityContext:
@@ -108,6 +108,8 @@ spec:
         secret:
           secretName: {{ .secretName }}
       {{- end }}
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       imagePullSecrets:

--- a/chart/k8skafka-controller/templates/metrics-rbac.yaml
+++ b/chart/k8skafka-controller/templates/metrics-rbac.yaml
@@ -17,6 +17,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: {{ include "k8skafka-controller.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/name: {{ include "k8skafka-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8skafka-controller.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8skafka-controller.fullname" . }}-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8skafka-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ include "k8skafka-controller.fullname" . }}-proxy
   labels:
     app.kubernetes.io/name: {{ include "k8skafka-controller.name" . }}

--- a/chart/k8skafka-controller/values.yaml
+++ b/chart/k8skafka-controller/values.yaml
@@ -81,6 +81,8 @@ securityContext:
   capabilities:
     drop: ["all"]
   readOnlyRootFilesystem: true
+
+podSecurityContext:
   runAsGroup: 10000
   runAsNonRoot: true
   runAsUser: 10000
@@ -119,7 +121,7 @@ prometheusRule:
 
 kubeRBACProxy:
   enabled: true
-
+  image: quay.io/brancz/kube-rbac-proxy:v0.14.2
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -127,5 +129,11 @@ kubeRBACProxy:
     readOnlyRootFilesystem: true
 
   resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 5m
+  #   memory: 64Mi
 
 tolerations: []


### PR DESCRIPTION
## Current situation
* There is no rolebinding for allowing the controllers sa to access itselfs metrics in the chart
* Invalid securityContext for the rbac proxy in the chart

## Proposal
Fix both.
